### PR TITLE
本番Hugo配信を静的ビルドに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ logs:
 	$(COMPOSE) logs -f
 
 hugo:
-	$(COMPOSE) run --rm fukuyoka_frontend --minify --baseURL https://${DOMAIN}
+	$(COMPOSE) run --rm fukuyoka_frontend --minify
 
 prepare:
 	$(COMPOSE) run --rm --no-deps $(SERVICE) cargo run --release --bin prepare -- --all
@@ -89,4 +89,3 @@ db-shell:
 
 db-logs:
 	$(COMPOSE) logs -f db
-

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ logs:
 	$(COMPOSE) logs -f
 
 hugo:
-	$(COMPOSE) exec -it fukuyoka_frontend hugo
+	$(COMPOSE) run --rm fukuyoka_frontend --minify --baseURL https://${DOMAIN}
 
 prepare:
 	$(COMPOSE) run --rm --no-deps $(SERVICE) cargo run --release --bin prepare -- --all

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -2,11 +2,17 @@ services:
   fukuyoka_frontend:
     environment:
       HUGO_ENV: development
-    command: server --bind 0.0.0.0 --port 1313 --baseURL http://localhost:51841 --appendPort=false
+    command: --watch --baseURL http://localhost:51841
+    restart: unless-stopped
 
   fukuyoka_proxy:
     ports:
       - "51841:80"
+    depends_on:
+      fukuyoka_frontend:
+        condition: service_started
+      fukuyoka_app:
+        condition: service_started
 
   cloudflared:
     profiles:

--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       HUGO_ENV: production
       DOMAIN: ${DOMAIN}
-    command: --minify --baseURL https://${DOMAIN}
+    command: --minify
     volumes:
       - ./frontend:/src
     restart: "no"

--- a/compose.yml
+++ b/compose.yml
@@ -31,10 +31,10 @@ services:
     environment:
       HUGO_ENV: production
       DOMAIN: ${DOMAIN}
-    command: server --bind 0.0.0.0 --port 1313 --baseURL https://${DOMAIN} 
+    command: --minify --baseURL https://${DOMAIN}
     volumes:
       - ./frontend:/src
-    restart: unless-stopped
+    restart: "no"
     networks:
       - fukuyoka
 
@@ -43,8 +43,9 @@ services:
     container_name: fukuyoka_proxy
     restart: unless-stopped
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/teapot.html:/etc/nginx/html/teapot.html:ro
+      - ./frontend/public:/var/www/hugo:ro
     healthcheck:
       test: ["CMD-SHELL", "nginx -t || exit 1"]
       start_period: 10s # DBやAPIの起動を待つための猶予期間
@@ -53,7 +54,7 @@ services:
       retries: 3
     depends_on:
       fukuyoka_frontend:
-        condition: service_started
+        condition: service_completed_successfully
       fukuyoka_app:
         condition: service_started
     networks:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -66,13 +66,9 @@ http {
     }
 
     location / {
-      set $backend_frontend http://fukuyoka_frontend:1313;
-      proxy_pass $backend_frontend;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_redirect off;
+      root /var/www/hugo;
+      index index.html;
+      try_files $uri $uri/ $uri/index.html =404;
     }
   }
   server{


### PR DESCRIPTION
## 概要・背景
本番環境でHugo dev serverが動作していたため、Hugoは静的ビルドのみを行い、nginxが生成物を直接配信する構成に変更しました。

## 関連Issue
[Bug] 本番環境でHugo dev serverが動作している #4

## 変更内容
- 本番のHugo実行を`hugo server`から静的ビルドに変更
- nginxで`frontend/public`を静的ファイルとして配信するように変更
- frontendコンテナ完了後にproxyが起動する依存条件へ変更
- 開発環境ではHugoのwatchビルドを使うようにoverrideを調整
- `make hugo`を静的ビルド用の実行方法に変更

## テスト方法
- 未実施