### PR TITLE
画像配信を軽量化しHugoを静的配信に変更

### DIFF
--- a/frontend/layouts/_default/_markup/render-image.html
+++ b/frontend/layouts/_default/_markup/render-image.html
@@ -1,16 +1,50 @@
 {{/*
-  Markdown image render hook: wraps image with figure + figcaption.
-  Caption priority: Title ("..." in Markdown) > Alt text
-  Usage in Markdown: ![alt text](/path.jpg "caption here")
+  Markdown image render hook.
+  - 自前 R2 (/photo/, photo.fukuyoka.dev, www.fukuyoka.dev/photo/) のみビルド時 WebP 化
+  - data-fullsrc に原寸URLを持たせ、image-modal.js が拡大時に取得
+  - 外部サイトの画像はそのまま (ビルドの外部依存を避ける)
+  Caption: Title ("...") > Alt
 */}}
-{{ $src := .Destination | safeURL }}
+{{ $rawSrc := .Destination }}
 {{ $alt := .Text | plainify }}
 {{ $title := .Title | plainify }}
 
+{{/* 自前画像のみを R2 origin の絶対URLに正規化 */}}
+{{ $fetchURL := "" }}
+{{ if hasPrefix $rawSrc "/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "/photo" $rawSrc) }}
+{{ else if hasPrefix $rawSrc "https://www.fukuyoka.dev/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "https://www.fukuyoka.dev/photo" $rawSrc) }}
+{{ else if hasPrefix $rawSrc "https://photo.fukuyoka.dev/" }}
+  {{ $fetchURL = $rawSrc }}
+{{ end }}
+
+{{ $displaySrc := $rawSrc }}
+{{ with $fetchURL }}
+  {{ $res := try (resources.GetRemote .) }}
+  {{ if $res.Err }}
+    {{ warnf "image fetch failed: %s (%s)" . $res.Err }}
+  {{ else }}
+    {{ with $res.Value }}
+      {{/* 元の比率を維持。元画像が幅1200未満なら拡大せずフォーマット変換のみ */}}
+      {{ $spec := "resize 1200x webp q78" }}
+      {{ if le .Width 1200 }}
+        {{ $spec = "webp q78" }}
+      {{ end }}
+      {{ $img := .Process $spec }}
+      {{ $displaySrc = $img.RelPermalink }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
 <figure class="md-image">
-  <img src="{{ $src }}" alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }} />
+  <img src="{{ $displaySrc | safeURL }}"
+       data-fullsrc="{{ $rawSrc | safeURL }}"
+       alt="{{ $alt }}"
+       loading="lazy"
+       decoding="async"
+       {{ with $title }}title="{{ . }}"{{ end }} />
   {{ if or $title $alt }}
     <figcaption>{{ if $title }}{{ $title }}{{ else }}{{ $alt }}{{ end }}</figcaption>
   {{ end }}
-  </figure>
-
+</figure>

--- a/frontend/layouts/_default/_markup/render-image.html
+++ b/frontend/layouts/_default/_markup/render-image.html
@@ -9,15 +9,7 @@
 {{ $alt := .Text | plainify }}
 {{ $title := .Title | plainify }}
 
-{{/* 自前画像のみを R2 origin の絶対URLに正規化 */}}
-{{ $fetchURL := "" }}
-{{ if hasPrefix $rawSrc "/photo/" }}
-  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "/photo" $rawSrc) }}
-{{ else if hasPrefix $rawSrc "https://www.fukuyoka.dev/photo/" }}
-  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "https://www.fukuyoka.dev/photo" $rawSrc) }}
-{{ else if hasPrefix $rawSrc "https://photo.fukuyoka.dev/" }}
-  {{ $fetchURL = $rawSrc }}
-{{ end }}
+{{ $fetchURL := partial "photo-fetch-url.html" $rawSrc }}
 
 {{ $displaySrc := $rawSrc }}
 {{ with $fetchURL }}
@@ -28,18 +20,29 @@
     {{ with $res.Value }}
       {{/* 元の比率を維持。元画像が幅1200未満なら拡大せずフォーマット変換のみ */}}
       {{ $spec := "resize 1200x webp q78" }}
-      {{ if le .Width 1200 }}
-        {{ $spec = "webp q78" }}
+      {{ $width := try .Width }}
+      {{ if $width.Err }}
+        {{ warnf "image width check failed: %s (%s)" $fetchURL $width.Err }}
+      {{ else }}
+        {{ if le $width.Value 1200 }}
+          {{ $spec = "webp q78" }}
+        {{ end }}
+        {{ $img := try (.Process $spec) }}
+        {{ if $img.Err }}
+          {{ warnf "image process failed: %s (%s)" $fetchURL $img.Err }}
+        {{ else }}
+          {{ with $img.Value }}
+            {{ $displaySrc = .RelPermalink }}
+          {{ end }}
+        {{ end }}
       {{ end }}
-      {{ $img := .Process $spec }}
-      {{ $displaySrc = $img.RelPermalink }}
     {{ end }}
   {{ end }}
 {{ end }}
 
 <figure class="md-image">
-  <img src="{{ $displaySrc | safeURL }}"
-       data-fullsrc="{{ $rawSrc | safeURL }}"
+  <img src="{{ $displaySrc }}"
+       data-fullsrc="{{ $rawSrc }}"
        alt="{{ $alt }}"
        loading="lazy"
        decoding="async"

--- a/frontend/layouts/partials/photo-fetch-url.html
+++ b/frontend/layouts/partials/photo-fetch-url.html
@@ -1,0 +1,10 @@
+{{ $src := . }}
+{{ $fetchURL := "" }}
+{{ if hasPrefix $src "/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "/photo" $src) }}
+{{ else if hasPrefix $src "https://www.fukuyoka.dev/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "https://www.fukuyoka.dev/photo" $src) }}
+{{ else if hasPrefix $src "https://photo.fukuyoka.dev/" }}
+  {{ $fetchURL = $src }}
+{{ end }}
+{{ return $fetchURL }}

--- a/frontend/layouts/partials/post-thumb.html
+++ b/frontend/layouts/partials/post-thumb.html
@@ -1,11 +1,7 @@
 {{/*
   Renders a square thumbnail for a post.
-  Preferred: set front matter `thumbnail` to a path or URL.
-  Fallback: use site favicon.
-  Examples:
-    thumbnail = "/images/sushi.jpg"
-    thumbnail = "images/sushi.jpg"   (will be normalized to start with /)
-    thumbnail = "https://example.com/cover.jpg"
+  - front matter `thumbnail` を WebP 小サイズに変換して配信 (ビルド時)
+  - 取得失敗 / favicon フォールバックは原URLのまま
 */}}
 
 {{ $imgURL := "" }}
@@ -21,7 +17,35 @@
   {{ $imgURL = "/favicon.png" }}
 {{ end }}
 
-<img src="{{ $imgURL }}" alt="{{ $.Title }}" loading="lazy" />
+{{/* 自前画像 (/photo/, www.fukuyoka.dev/photo/, photo.fukuyoka.dev) のみ R2 origin に正規化 */}}
+{{ $fetchURL := "" }}
+{{ if hasPrefix $imgURL "/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "/photo" $imgURL) }}
+{{ else if hasPrefix $imgURL "https://www.fukuyoka.dev/photo/" }}
+  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "https://www.fukuyoka.dev/photo" $imgURL) }}
+{{ else if hasPrefix $imgURL "https://photo.fukuyoka.dev/" }}
+  {{ $fetchURL = $imgURL }}
+{{ end }}
+
+{{ $displaySrc := $imgURL }}
+{{ with $fetchURL }}
+  {{ $res := try (resources.GetRemote .) }}
+  {{ if $res.Err }}
+    {{ warnf "thumbnail fetch failed: %s (%s)" . $res.Err }}
+  {{ else }}
+    {{ with $res.Value }}
+      {{/* 元の比率を維持。CSS の object-fit: cover で表示時に正方形へ整形される */}}
+      {{ $spec := "resize 600x webp q72" }}
+      {{ if le .Width 600 }}
+        {{ $spec = "webp q72" }}
+      {{ end }}
+      {{ $thumb := .Process $spec }}
+      {{ $displaySrc = $thumb.RelPermalink }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<img src="{{ $displaySrc | safeURL }}" alt="{{ $.Title }}" loading="lazy" decoding="async" />
 <div class="thumb-caption">
   <p class="thumb-title">{{ $.Title }}</p>
   <p class="thumb-meta">
@@ -36,5 +60,5 @@
       {{ end }}
     </div>
   {{ end }}
-  
+
 </div>

--- a/frontend/layouts/partials/post-thumb.html
+++ b/frontend/layouts/partials/post-thumb.html
@@ -17,15 +17,7 @@
   {{ $imgURL = "/favicon.png" }}
 {{ end }}
 
-{{/* 自前画像 (/photo/, www.fukuyoka.dev/photo/, photo.fukuyoka.dev) のみ R2 origin に正規化 */}}
-{{ $fetchURL := "" }}
-{{ if hasPrefix $imgURL "/photo/" }}
-  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "/photo" $imgURL) }}
-{{ else if hasPrefix $imgURL "https://www.fukuyoka.dev/photo/" }}
-  {{ $fetchURL = printf "https://photo.fukuyoka.dev%s" (strings.TrimPrefix "https://www.fukuyoka.dev/photo" $imgURL) }}
-{{ else if hasPrefix $imgURL "https://photo.fukuyoka.dev/" }}
-  {{ $fetchURL = $imgURL }}
-{{ end }}
+{{ $fetchURL := partial "photo-fetch-url.html" $imgURL }}
 
 {{ $displaySrc := $imgURL }}
 {{ with $fetchURL }}
@@ -36,16 +28,27 @@
     {{ with $res.Value }}
       {{/* 元の比率を維持。CSS の object-fit: cover で表示時に正方形へ整形される */}}
       {{ $spec := "resize 600x webp q72" }}
-      {{ if le .Width 600 }}
-        {{ $spec = "webp q72" }}
+      {{ $width := try .Width }}
+      {{ if $width.Err }}
+        {{ warnf "thumbnail width check failed: %s (%s)" $fetchURL $width.Err }}
+      {{ else }}
+        {{ if le $width.Value 600 }}
+          {{ $spec = "webp q72" }}
+        {{ end }}
+        {{ $thumb := try (.Process $spec) }}
+        {{ if $thumb.Err }}
+          {{ warnf "thumbnail process failed: %s (%s)" $fetchURL $thumb.Err }}
+        {{ else }}
+          {{ with $thumb.Value }}
+            {{ $displaySrc = .RelPermalink }}
+          {{ end }}
+        {{ end }}
       {{ end }}
-      {{ $thumb := .Process $spec }}
-      {{ $displaySrc = $thumb.RelPermalink }}
     {{ end }}
   {{ end }}
 {{ end }}
 
-<img src="{{ $displaySrc | safeURL }}" alt="{{ $.Title }}" loading="lazy" decoding="async" />
+<img src="{{ $displaySrc }}" alt="{{ $.Title }}" loading="lazy" decoding="async" />
 <div class="thumb-caption">
   <p class="thumb-title">{{ $.Title }}</p>
   <p class="thumb-meta">

--- a/frontend/static/js/image-modal.js
+++ b/frontend/static/js/image-modal.js
@@ -55,7 +55,7 @@
       img.addEventListener('click', (ev) => {
         // Avoid navigating if image is inside a link
         if (img.closest('a')) ev.preventDefault();
-        const src = img.currentSrc || img.src;
+        const src = img.dataset.fullsrc || img.currentSrc || img.src;
         const fig = img.closest('figure');
         const captionText = fig && fig.querySelector('figcaption') ? fig.querySelector('figcaption').textContent : img.alt;
         openModal(src, captionText);


### PR DESCRIPTION
## 概要・背景
画像の読み込み速度改善とデータ通信量削減のため、Hugoビルド時に自前画像をWebPへ変換して配信するようにしました。あわせて本番環境ではHugoサーバーを常駐させず、生成済みの静的ファイルをnginxから配信する構成に変更しています。

## 関連Issue
画像の読み込み速度とデータ通信量削減について #1

## 変更内容
- Markdown本文画像と投稿サムネイルをビルド時にWebPへ変換
- モーダル表示では元画像URLを参照するように調整
- 本番Hugoコンテナを静的ビルド用途に変更し、nginxから `frontend/public` を配信
- 開発環境のHugo起動コマンドと依存関係を調整
- `make hugo` をコンテナ実行の静的ビルドに変更

## テスト方法
- `make hugo`