### PR TITLE
fix: SQL識別子のバリデーションを追加しインジェクションを防止

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,32 @@
+use regex::Regex;
+use std::sync::OnceLock;
 use tokio_postgres::{Client, NoTls};
 use std::env;
+
+/// Allowed pattern for SQL identifiers such as table or index names.
+const IDENTIFIER_PATTERN: &str = r"^[A-Za-z_][A-Za-z0-9_]*$";
+
+/// Validate a SQL identifier against a safe whitelist pattern.
+/// tokio-postgres does not support parameterized identifiers, so any value
+/// interpolated into SQL must be validated first to prevent SQL injection.
+pub fn validate_identifier(name: &str) -> Result<&str, String> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(IDENTIFIER_PATTERN).expect("IDENTIFIER_PATTERN must be a valid regex")
+    });
+    if re.is_match(name) {
+        Ok(name)
+    } else {
+        Err(format!("invalid SQL identifier: {name:?}"))
+    }
+}
+
+/// Read POSTGRES_TABLE from the environment and validate it as a SQL identifier.
+pub fn get_table_name() -> Result<String, String> {
+    let name = env::var("POSTGRES_TABLE")
+        .map_err(|_| "POSTGRES_TABLEを設定してください".to_string())?;
+    validate_identifier(&name).map(|s| s.to_string())
+}
 
 pub async fn connect_db() -> Result<Client, Box<dyn std::error::Error>> {
     let user = env::var("POSTGRES_USER").unwrap_or_else(|_| "postgres".to_string());
@@ -77,7 +104,7 @@ async fn enable_extensions(client: &Client) -> Result<(), Box<dyn std::error::Er
 }
 
 async fn create_table(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = env::var("POSTGRES_TABLE").map_err(|_| "POSTGRES_TABLEを設定してください")?;
+    let table_name = get_table_name()?;
     client
         .batch_execute(
             &format!(
@@ -98,7 +125,7 @@ async fn create_table(client: &Client) -> Result<(), Box<dyn std::error::Error>>
 }
 
 async fn create_indexes(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = env::var("POSTGRES_TABLE").map_err(|_| "POSTGRES_TABLEを設定してください")?;
+    let table_name = get_table_name()?;
     client
         .batch_execute(
             &format!(
@@ -120,7 +147,7 @@ async fn insert_data(
     tokens: &str,
     embedding_str: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = env::var("POSTGRES_TABLE").map_err(|_| "POSTGRES_TABLEを設定してください")?;
+    let table_name = get_table_name()?;
     client
         .execute(
             &format!("INSERT INTO {table_name} (title, url, thumbnail, tokens, embeds) VALUES ($1, $2, $3, $4, $5::text::vector)"),
@@ -134,4 +161,34 @@ pub fn load_json(file_path: &str) -> Result<Vec<serde_json::Value>, Box<dyn std:
     let data = std::fs::read_to_string(file_path)?;
     let json_data: Vec<serde_json::Value> = serde_json::from_str(&data)?;
     Ok(json_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_identifier_accepts_valid_names() {
+        for ok in ["posts", "Posts", "_posts", "posts_2024", "P1", "_"] {
+            assert_eq!(validate_identifier(ok), Ok(ok));
+        }
+    }
+
+    #[test]
+    fn test_validate_identifier_rejects_injection_attempts() {
+        for ng in [
+            "posts; DROP TABLE users; --",
+            "posts;",
+            "public.posts",
+            "posts\"",
+            "posts'",
+            "posts`",
+            "post tb",
+            "1posts",
+            "posts-bad",
+            "",
+        ] {
+            assert!(validate_identifier(ng).is_err(), "should reject: {ng}");
+        }
+    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,9 +4,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio_postgres::Client;
 use serde::{Deserialize, Serialize};
-use std::env;
 
-use crate::db::connect_db;
+use crate::db::{connect_db, get_table_name};
 use crate::embedding::EmbeddingModel;
 use crate::morphology::morphology;
 
@@ -110,9 +109,9 @@ fn rrf_rerank(embed_results: Vec<SearchResult>, token_results: Vec<SearchResult>
 }
 
 async fn vector_similarity_search(client: &Client, embedding: Vec<f32>, top_k: usize) -> Vec<SearchResult> {
-    let table_name = match env::var("POSTGRES_TABLE") {
+    let table_name = match get_table_name() {
         Ok(v) => v,
-        Err(_) => { println!("POSTGRES_TABLEを設定してください"); return Vec::new(); }
+        Err(e) => { println!("{e}"); return Vec::new(); }
     };
     let sql = format!(
         "SELECT title, url, thumbnail, embeds <=> $1::text::vector AS score \
@@ -138,9 +137,9 @@ async fn vector_similarity_search(client: &Client, embedding: Vec<f32>, top_k: u
 }
 
 async fn bm25(client: &Client, tokens: String, top_k: usize) -> Vec<SearchResult> {
-    let table_name = match env::var("POSTGRES_TABLE") {
+    let table_name = match get_table_name() {
         Ok(v) => v,
-        Err(_) => { println!("POSTGRES_TABLEを設定してください"); return Vec::new(); }
+        Err(e) => { println!("{e}"); return Vec::new(); }
     };
     let sql = format!(
         "SELECT title, url, thumbnail, tokens <@> to_bm25query($1, '{table_name}_tokens_idx') AS score \


### PR DESCRIPTION
## 概要・背景

SQL 文を `format!` で組み立てている箇所において、テーブル名・インデックス名が識別子バリデーションを経ずに SQL へ埋め込まれており、パラメータ扱いを誤れば SQL インジェクションに繋がる素地があった。本 PR では識別子をホワイトリスト（`/^[A-Za-z_][A-Za-z0-9_]*$/`）で検証するヘルパを導入し、全 SQL 構築箇所をその経路に統一する。

## 関連Issue

- Closes #21

## 変更内容

- `src/db.rs`
  - `validate_identifier(name: &str)` を追加。`OnceLock<Regex>` でコンパイル済み正規表現をキャッシュし、識別子を検証
  - `get_table_name()` を追加。`POSTGRES_TABLE` 環境変数の読み込み＋識別子バリデーションを兼務
  - `create_table` / `create_indexes` / `insert_data` を `get_table_name()?` 経由に変更（これまでの直接 `env::var` を置換）
  - バリデーションの単体テストを追加（正常系・インジェクション攻撃パターンの拒否）
- `src/search.rs`
  - `vector_similarity_search` / `bm25` のテーブル名取得を `get_table_name()` 経由に変更
  - バリデーション/未設定時は従来通り `println!` でログ出力して空結果を返す（既存の挙動を踏襲）

値（`title` / `url` / `tokens` / `embedding` 等）は引き続きパラメータ（`$1`, `$2` ...）で渡すため、アプリケーション入力は従来通り安全。

## テスト方法

```sh
cargo check
cargo test
```

実行結果:

```
running 4 tests
test db::tests::test_validate_identifier_accepts_valid_names ... ok
test db::tests::test_validate_identifier_rejects_injection_attempts ... ok
test post::tests::test_parse_frontmatter ... ok
test post::tests::test_clean_markdown ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
```

`cargo check` も既存の unrelated 警告（`search.rs:21` の未使用 `score` フィールド）のみで通過。
