### PR TITLE
fix: 埋め込み生成時のaltテキスト欠落とpassage:プレフィックス不足を修正

### DIFF
--- a/src/bin/prepare.rs
+++ b/src/bin/prepare.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use regex::Regex;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -43,44 +42,13 @@ struct PreparedPost {
     search_text: String,
 }
 
-/// Extract alt texts from markdown body
-fn extract_alt_texts(body: &str) -> Vec<String> {
-    let re = Regex::new(r"!\[(.*?)\]\(.*?\)").unwrap();
-    re.captures_iter(body)
-        .filter_map(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
-}
-
-/// Create text for embedding: title + body + alt texts
-fn create_embedding_text(post: &Post) -> String {
-    let alt_texts = extract_alt_texts(&post.body);
-    let parts: Vec<&str> = vec![&post.title, &post.body];
-
-    let mut full_text = parts.join(" ");
-
-    if !alt_texts.is_empty() {
-        full_text.push(' ');
-        full_text.push_str(&alt_texts.join(" "));
-    }
-
-    full_text
-}
-
-/// Create text for morphology: title + body + alt texts (without markdown)
+/// Create text for morphology: title + body + alt texts (without `passage:` prefix)
 fn create_morphology_text(post: &Post) -> String {
-    let alt_texts = extract_alt_texts(&post.body);
+    let mut text = format!("{} {}", post.title, post.body);
 
-    // Clean body: remove markdown images but keep other content
-    let re_images = Regex::new(r"!\[.*?\]\(.*?\)").unwrap();
-    let clean_body = re_images.replace_all(&post.body, "");
-
-    let mut text = format!("{} {}", post.title, clean_body);
-
-    if !alt_texts.is_empty() {
+    if !post.alt_texts.is_empty() {
         text.push(' ');
-        text.push_str(&alt_texts.join(" "));
+        text.push_str(&post.alt_texts.join(" "));
     }
 
     text
@@ -90,7 +58,7 @@ fn process_posts(posts: Vec<Post>, model: &EmbeddingModel) -> Vec<PreparedPost> 
     posts
         .into_iter()
         .filter_map(|post| {
-            let embedding_text = create_embedding_text(&post);
+            let embedding_text = post.text_for_embedding();
             let morphology_text = create_morphology_text(&post);
 
             // Generate embedding


### PR DESCRIPTION
## 概要・背景

投稿の埋め込み生成時に2つのバグがあり、ベクトル検索の精度が低下していたのを修正します。`src/bin/prepare.rs` が `Post` 構造体に既に存在する正しい実装を再利用していなかったことが根本原因です。

## 関連Issue

Closes #22

## 変更内容

`src/bin/prepare.rs` の重複実装を削除し、`Post` のメソッド/フィールドを再利用するように変更しました。

- ローカル `extract_alt_texts` 関数を削除（`Post.alt_texts` フィールドと重複）
- `create_embedding_text` 関数を削除し、`Post::text_for_embedding()` を使用するように変更
  - これにより multilingual-e5 必須の `passage:` プレフィックスが付与されるようになり、`src/search.rs:54` の `query:` プレフィックスと整合
  - 画像の alt テキストも `Post::text_for_embedding()` 経由で正しく埋め込みに含まれるように
- `create_morphology_text` を `post.body` から再抽出せず `post.alt_texts` を直接参照するように修正
  - alt テキストが形態素解析（BM25 用トークン）にも反映されるように
  - `passage:` プレフィックスは BM25 用テキストには不要なため意図的に付与しない
- 未使用になった `regex::Regex` の import を削除

**背景**: `load_post` は `body` に `clean_markdown()` を掛ける前の段階で alt テキストを抽出して `Post.alt_texts` に保持しています。しかし `prepare.rs` の旧実装は画像除去済みの `post.body` に対して再度 `extract_alt_texts` を呼んでいたため、常に空のベクトルが返っていました。

## テスト方法

リポジトリの `AGENTS.md` に従い、ローカルの cargo で検証しました。

```sh
# 型チェック（binary 個別）
$ cargo check --bin prepare
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.99s
（search.rs:22 の field `score` is never read 警告は本PRと無関係の既存警告）

# 全テスト
$ cargo test
running 2 tests
test post::tests::test_parse_frontmatter ... ok
test post::tests::test_clean_markdown ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 measured; 0 filtered out
```

実データでの確認手順（issue の再現手順に対応）:

1. `make prepare` を実行して `posts.json` を生成
2. 画像を含む記事（例: `irochaya.md`）の embedding 対象テキストを確認
   - `passage:` プレフィックスが付与されていること
   - alt テキスト（例: 看板メニューの写真説明）がテキストに含まれていること
3. `search.rs` の `query:` プレフィックスとベクトル空間が整合していることを確認
