### PR TITLE
fix: HFモデルキャッシュの永続化とボリューム保護

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CURRENT_USER := $(shell whoami)
 CURRENT_GROUP := $(shell id -gn)
 BUILD_ARGS := --build-arg UID=$(CURRENT_UID) --build-arg GID=$(CURRENT_GID) --build-arg USER=$(CURRENT_USER) --build-arg GROUP=$(CURRENT_GROUP)
 
-.PHONY: build up down logs in prepare ps hugo clean help \
+.PHONY: build up down logs in prepare ps hugo clean clean-all help \
         restart restart-db \
         db-shell db-logs \
         dev dev-build dev-down dev-logs
@@ -28,7 +28,8 @@ help:
 	@echo "  hugo           - Build the frontend with Hugo"
 	@echo "  db-shell       - Open psql shell in the database container"
 	@echo "  db-logs        - View database container logs"
-	@echo "  clean          - Remove containers, networks, and volumes"
+	@echo "  clean          - Remove containers and networks (volumes preserved)"
+	@echo "  clean-all      - Remove containers, networks, and ALL volumes (including model cache)"
 	@echo ""
 	@echo "Development (localhost):"
 	@echo "  dev-build      - Build images for local dev"
@@ -51,6 +52,9 @@ dev-logs:
 	$(COMPOSE_DEV) logs -f
 
 clean:
+	$(COMPOSE) down --remove-orphans
+
+clean-all:
 	$(COMPOSE) down -v --remove-orphans
 
 build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,8 @@ RUN groupadd -f -g ${GID} ${GROUP}
 RUN useradd -ms /bin/zsh -u ${UID} -g ${GID} -G sudo ${USER} &&\
     echo ${USER}:${USER} | chpasswd
 
+RUN mkdir -p /hf-cache && chown ${UID}:${GID} /hf-cache
+
 USER ${USER}
 WORKDIR /home/${USER}
 

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -14,7 +14,7 @@ impl EmbeddingModel {
     pub fn new(model_id: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let device = Device::Cpu;
 
-        let cache = Cache::default();
+        let cache = Cache::from_env();
         let cached = cache.repo(Repo::model(model_id.to_string()));
         let (model_file, config_file, tokenizer_file) = match (
             cached.get("model.safetensors"),
@@ -27,7 +27,7 @@ impl EmbeddingModel {
             }
             _ => {
                 println!("Downloading model files...");
-                let api = ApiBuilder::new().with_progress(true).build()?;
+                let api = ApiBuilder::from_env().with_progress(true).build()?;
                 let repo = api.model(model_id.to_string());
                 (
                     repo.get("model.safetensors")?,


### PR DESCRIPTION
## Summary
- Dockerfileで`/hf-cache`ディレクトリを非rootユーザー所有で事前作成し、named volumeへの書き込みを可能にした
- `make clean`からボリューム削除(`-v`)を分離し、`make clean-all`に移動。モデルキャッシュの意図しない消失を防止

## 原因
- named volumeマウント時にDockerが`/hf-cache`をroot:root (755)で自動作成するため、非rootユーザーが書き込めなかった
- `make clean`の`docker compose down -v`がキャッシュボリュームごと削除していた

## 適用後の手順
既存の空ボリュームを削除して再作成が必要:
```bash
make clean        # コンテナ停止（ボリュームは残る）
docker volume rm fukuyokadev_hf_cache
make build        # イメージ再ビルド
make up           # 起動（正しいパーミッションでボリューム再作成）
```

## Test plan
- [ ] `make build` でイメージ再ビルド
- [ ] `make prepare` 実行 → モデルダウンロード完了を確認
- [ ] 再度 `make prepare` 実行 → "Using cached model files" が表示されダウンロードが走らないことを確認
- [ ] `make clean` 後に `make up` → キャッシュが保持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)